### PR TITLE
Ignore archives from coverage reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>*Archive/**/*</exclude>
+					</excludes>
+				</configuration>
 				<version>0.7.6.201602180812</version>
 				<executions>
 					<execution>

--- a/src/main/java/db/structure/indexTree/IndexTreeCeption.java
+++ b/src/main/java/db/structure/indexTree/IndexTreeCeption.java
@@ -22,7 +22,7 @@ import db.data.IntegerArrayList;
 import db.search.Operator;
 import db.structure.Column;
 import db.structure.Table;
-import sj.simpleDB.treeIndexing.SIndexingTreeType;
+import zArchive.sj.simpleDB.treeIndexing.SIndexingTreeType;
 
 /**
  * Point très IMPORTANT :

--- a/src/main/java/zArchive/sj/simpleDB/customTreeIndexing/TIndexingNode.java
+++ b/src/main/java/zArchive/sj/simpleDB/customTreeIndexing/TIndexingNode.java
@@ -1,4 +1,4 @@
-package sj.simpleDB.customTreeIndexing;
+package zArchive.sj.simpleDB.customTreeIndexing;
 
 import java.util.ArrayList;
 

--- a/src/main/java/zArchive/sj/simpleDB/customTreeIndexing/TIndexingNodeInterface.java
+++ b/src/main/java/zArchive/sj/simpleDB/customTreeIndexing/TIndexingNodeInterface.java
@@ -1,4 +1,4 @@
-package sj.simpleDB.customTreeIndexing;
+package zArchive.sj.simpleDB.customTreeIndexing;
 
 public interface TIndexingNodeInterface {
 	

--- a/src/main/java/zArchive/sj/simpleDB/customTreeIndexing/TIndexingTree.java
+++ b/src/main/java/zArchive/sj/simpleDB/customTreeIndexing/TIndexingTree.java
@@ -1,4 +1,4 @@
-package sj.simpleDB.customTreeIndexing;
+package zArchive.sj.simpleDB.customTreeIndexing;
 
 
 /**

--- a/src/main/java/zArchive/sj/simpleDB/customTreeIndexing/package-info.java
+++ b/src/main/java/zArchive/sj/simpleDB/customTreeIndexing/package-info.java
@@ -24,4 +24,4 @@
  * 
  */
 
-package sj.simpleDB.customTreeIndexing;
+package zArchive.sj.simpleDB.customTreeIndexing;

--- a/src/main/java/zArchive/sj/simpleDB/treeIndexing/SIndexingTreeFinder.java
+++ b/src/main/java/zArchive/sj/simpleDB/treeIndexing/SIndexingTreeFinder.java
@@ -1,4 +1,4 @@
-package sj.simpleDB.treeIndexing;
+package zArchive.sj.simpleDB.treeIndexing;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/zArchive/sj/simpleDB/treeIndexing/SIndexingTreeFinderItem.java
+++ b/src/main/java/zArchive/sj/simpleDB/treeIndexing/SIndexingTreeFinderItem.java
@@ -1,4 +1,4 @@
-package sj.simpleDB.treeIndexing;
+package zArchive.sj.simpleDB.treeIndexing;
 
 
 public class SIndexingTreeFinderItem implements Comparable<SIndexingTreeFinderItem> {

--- a/src/main/java/zArchive/sj/simpleDB/treeIndexing/SIndexingTreeMainTest.java
+++ b/src/main/java/zArchive/sj/simpleDB/treeIndexing/SIndexingTreeMainTest.java
@@ -1,4 +1,4 @@
-package sj.simpleDB.treeIndexing;
+package zArchive.sj.simpleDB.treeIndexing;
 
 public class SIndexingTreeMainTest {
 

--- a/src/main/java/zArchive/sj/simpleDB/treeIndexing/SIndexingTreeType.java
+++ b/src/main/java/zArchive/sj/simpleDB/treeIndexing/SIndexingTreeType.java
@@ -1,4 +1,4 @@
-package sj.simpleDB.treeIndexing;
+package zArchive.sj.simpleDB.treeIndexing;
 
 public enum SIndexingTreeType {
 	// Unused, right now

--- a/src/main/java/zArchive/sj/simpleDB/treeIndexing/package-info.java
+++ b/src/main/java/zArchive/sj/simpleDB/treeIndexing/package-info.java
@@ -9,4 +9,4 @@
  * juste quelque chose de fonctionnel et un minimum optimisé.
  * 
  */
-package sj.simpleDB.treeIndexing;
+package zArchive.sj.simpleDB.treeIndexing;


### PR DESCRIPTION
Ignores everything in an `*Archive` package from coverages tests because this code is not used anymore and testing it is irrelevant.